### PR TITLE
Automatic discovery of nagios|monitoring-plugins utils.pm

### DIFF
--- a/check_ro_mounts.pl
+++ b/check_ro_mounts.pl
@@ -25,7 +25,9 @@
 
 use strict;
 use Getopt::Long;
-use lib "/usr/lib/nagios/plugins";
+use FindBin;
+use lib "$FindBin::Bin";
+use lib '@libexecdir@';
 use utils qw (%ERRORS &support);
 
 my $name = 'RO_MOUNTS';


### PR DESCRIPTION
Instead of using a static path to find the utils.pm from the nagios-plugins-perl (RHEL/Enterprise Linux packages) or monitoring-plugins-common (Debian, Ubuntu packages), use `FindBin` to dynamically use same path where the plugin is saved in.